### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ var hljsDylan = require('highlightjs-dylan');
 hljs.registerLanguage("dylan", hljsDylan);
 ```
 
+## Testing
+
+To test this highlighter see [the highlight.js 3rd party quick
+start](https://github.com/highlightjs/highlight.js/blob/main/extra/3RD_PARTY_QUICK_START.md).
+
+For the impatient, my (cgay) experience was that I needed to do the following steps:
+
+1. Clone the `highlight.js` repository and run `npm install` in it.
+1. `cd extra` and create a symlink to the `highlightjs-dylan` repository.
+1. In `highlightjs-dylan` modify the file `test/markup/sample.txt` with the code you want
+   to test.
+1. In `highlight.js` run `npm run build; npm run test`.
+1. Verify that the displayed diff looks correct and, if yes, copy it into
+   `test/markup/sample.expect.txt`.
+1. Go to step 3.
+
 ## License
 This code is released under the MIT License. See [LICENSE][1] file
 for details.

--- a/src/dylan.js
+++ b/src/dylan.js
@@ -48,7 +48,7 @@ module.exports = function(hljs) {
     },
     {
       className: 'symbol',
-      begin: '#' + DYLAN_WORD
+      begin: '#"' + DYLAN_WORD + '"'
     },
     {
       className: 'symbol',

--- a/src/dylan.js
+++ b/src/dylan.js
@@ -44,8 +44,8 @@ module.exports = function(hljs) {
   const DYLAN_WORD = '[a-z\-+\*/^=#!%$_><@\?~][a-z0-9\-+\*/^=#!%$_><@\?~]*';
   const KEYWORDS = {
     $pattern: DYLAN_WORD,
-    literal: DYLAN_HASH_WORDS.join(" "),
-    keyword: DYLAN_RESERVED_WORDS.join(" ")
+    literal: DYLAN_HASH_WORDS,
+    keyword: DYLAN_RESERVED_WORDS
   };
   const DYLAN_CODE = {
     case_insensitive: true,

--- a/src/dylan.js
+++ b/src/dylan.js
@@ -29,9 +29,10 @@ module.exports = function(hljs) {
     "select", "unless", "until", "while"
   ];
   const DYLAN_FUNCTION_WORDS = [];
-  const DYLAN_DEFINE_BODY_WORDS = ["class", "library", "method", "module"];
+  const DYLAN_DEFINE_BODY_WORDS = ["class", "function", "library", "method", "module"];
   const DYLAN_DEFINE_LIST_WORDS = ["constant", "variable", "domain"];
-  const DYLAN_RESERVED_WORDS = [].concat(DYLAN_CORE_WORDS,
+  const DYLAN_RESERVED_WORDS = [].concat(
+    DYLAN_CORE_WORDS,
     DYLAN_BEGIN_WORDS,
     DYLAN_FUNCTION_WORDS,
     DYLAN_DEFINE_BODY_WORDS.map(function(word) {

--- a/src/dylan.js
+++ b/src/dylan.js
@@ -72,7 +72,14 @@ module.exports = function(hljs) {
         end: '\'',
         illegal: '.'
       },
-      hljs.C_NUMBER_MODE,
+      {
+        scope: 'number',
+        begin: ('(#[bB][01][01_]*)'
+                + '|(#[oO][0-7][0-7_]*)'
+                + '|([-+]?[0-9][0-9_]*([.][0-9][0-9_]*([eEsSdD][0-9]+)?)?)'
+                + '|(#[xX][a-fA-F0-9][a-fA-F0-9_]*)'),
+        relevance: 0
+      },
       hljs.QUOTE_STRING_MODE,
       hljs.C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE

--- a/src/dylan.js
+++ b/src/dylan.js
@@ -51,30 +51,31 @@ module.exports = function(hljs) {
     case_insensitive: true,
     className: 'dylan',
     keywords: KEYWORDS,
-    contains: [{
-      className: 'class',
-      begin: '<' + DYLAN_WORD + '>',
-      relevance: 0
-    },
-    {
-      className: 'symbol',
-      begin: '#"' + DYLAN_WORD + '"'
-    },
-    {
-      className: 'symbol',
-      begin: DYLAN_WORD + ':',
-      relevance: 0
-    },
-    {
-      className: 'string',
-      begin: '\'\\\\?.',
-      end: '\'',
-      illegal: '.'
-    },
-    hljs.C_NUMBER_MODE,
-    hljs.QUOTE_STRING_MODE,
-    hljs.C_LINE_COMMENT_MODE,
-    hljs.C_BLOCK_COMMENT_MODE
+    contains: [
+      {
+        className: 'class',
+        begin: '<' + DYLAN_WORD + '>',
+        relevance: 0
+      },
+      {
+        className: 'symbol',
+        begin: '#"' + DYLAN_WORD + '"'
+      },
+      {
+        className: 'symbol',
+        begin: DYLAN_WORD + ':',
+        relevance: 0
+      },
+      {
+        className: 'string',
+        begin: '\'\\\\?.',
+        end: '\'',
+        illegal: '.'
+      },
+      hljs.C_NUMBER_MODE,
+      hljs.QUOTE_STRING_MODE,
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE
     ]
   };
 

--- a/src/dylan.js
+++ b/src/dylan.js
@@ -1,4 +1,13 @@
 /*
+Language: Dylan
+Description: Dylan language definition for highlight.js
+Author: Peter Hull <peterhull90@gmail.com>
+Category: functional
+Website: https://opendylan.org
+*/
+
+
+/*
  * highlight.js Dylan syntax highlighting definition
  *
  * @see https://github.com/highlightjs/highlight.js

--- a/src/dylan.js
+++ b/src/dylan.js
@@ -49,25 +49,25 @@ module.exports = function(hljs) {
   };
   const DYLAN_CODE = {
     case_insensitive: true,
-    className: 'dylan',
+    scope: 'dylan',
     keywords: KEYWORDS,
     contains: [
       {
-        className: 'class',
+        scope: 'class',
         begin: '<' + DYLAN_WORD + '>',
         relevance: 0
       },
       {
-        className: 'symbol',
+        scope: 'symbol',
         begin: '#"' + DYLAN_WORD + '"'
       },
       {
-        className: 'symbol',
+        scope: 'symbol',
         begin: DYLAN_WORD + ':',
         relevance: 0
       },
       {
-        className: 'string',
+        scope: 'string',
         begin: '\'\\\\?.',
         end: '\'',
         illegal: '.'

--- a/src/dylan.js
+++ b/src/dylan.js
@@ -41,7 +41,8 @@ module.exports = function(hljs) {
     DYLAN_DEFINE_LIST_WORDS
   );
   const DYLAN_HASH_WORDS = ["#t", "#f", "#next", "#rest", "#key", "#all-keys", "#include"];
-  const DYLAN_WORD = '[a-z\-+\*/^=#!%$_><@\?~][a-z0-9\-+\*/^=#!%$_><@\?~]*';
+  // If you modify this regular expression you should probably also update the one in vscode-dylan.
+  const DYLAN_WORD = '([a-zA-Z]|[0-9][a-zA-Z][a-zA-Z]|[!&*<>|^$%@_][a-zA-Z])[-+~?/=!&*<>|^$%@_a-zA-Z0-9]*';
   const KEYWORDS = {
     $pattern: DYLAN_WORD,
     literal: DYLAN_HASH_WORDS,

--- a/test/markup/sample.expect.txt
+++ b/test/markup/sample.expect.txt
@@ -19,7 +19,7 @@
   <span class="hljs-keyword">end</span> if-let
 <span class="hljs-keyword">end</span> <span class="hljs-keyword">method</span> add;
 
-<span class="hljs-keyword">define</span> function check()
+<span class="hljs-keyword">define</span> <span class="hljs-keyword">function</span> check()
   <span class="hljs-keyword">let</span> truck = make(<span class="hljs-class">&lt;truck&gt;</span>, <span class="hljs-symbol">tons:</span> <span class="hljs-number">25</span>);
   format-out(<span class="hljs-string">&quot;%s&#x27;s truck can carry %d\n&quot;</span>, 
              truck.owner,
@@ -45,7 +45,7 @@
   next-method() + t.capacity * <span class="hljs-number">10.0</span>;
 <span class="hljs-keyword">end</span> <span class="hljs-keyword">method</span>;
 
-<span class="hljs-keyword">define</span> function make-fibonacci()
+<span class="hljs-keyword">define</span> <span class="hljs-keyword">function</span> make-fibonacci()
   <span class="hljs-keyword">let</span> n = <span class="hljs-number">0</span>;
   <span class="hljs-keyword">let</span> m = <span class="hljs-number">1</span>;
   <span class="hljs-keyword">method</span> ()

--- a/test/markup/sample.expect.txt
+++ b/test/markup/sample.expect.txt
@@ -14,7 +14,9 @@
 
 <span class="hljs-keyword">define</span> <span class="hljs-keyword">method</span> add (x :: <span class="hljs-class">&lt;integer&gt;</span>, y :: <span class="hljs-class">&lt;integer&gt;</span>) 
   =&gt; ( sum :: <span class="hljs-class">&lt;integer&gt;</span>)
- x + y
+  if-let (x = <span class="hljs-number">99</span>)
+    x + y
+  <span class="hljs-keyword">end</span> if-let
 <span class="hljs-keyword">end</span> <span class="hljs-keyword">method</span> add;
 
 <span class="hljs-keyword">define</span> function check()

--- a/test/markup/sample.txt
+++ b/test/markup/sample.txt
@@ -14,7 +14,9 @@ end class <truck>;
 
 define method add (x :: <integer>, y :: <integer>) 
   => ( sum :: <integer>)
- x + y
+  if-let (x = 99)
+    x + y
+  end if-let
 end method add;
 
 define function check()


### PR DESCRIPTION
I started looking at this because of #7 .  Unfortunately I discovered that what's happening in our Matrix channel is because `highlightjs-dylan` isn't being used at all.  Neither the Element folks (I chatted with them) nor the highlight.js folks (according to their docs) want to add more obscure languages to their products so we apparently can't fix the highlighting in our channel.

Nevertheless, I think these changes should significantly improve the highlighting done by this plugin.

Closes #7 